### PR TITLE
Don't remove -T1 suffix before SM BGC check

### DIFF
--- a/bin/funannotate-functional.py
+++ b/bin/funannotate-functional.py
@@ -1059,7 +1059,7 @@ if lib.checkannotations(antismash_input):
         with open(Proteins, 'rU') as input:
             SeqRecords = SeqIO.parse(Proteins, 'fasta')
             for record in SeqRecords:
-                genename = record.id.split('-T')[0]
+                genename = record.id
                 if genename in AllProts:
                     SeqIO.write(record, output, 'fasta')
     cmd = ['diamond', 'blastp', '--sensitive', '--query', mibig_fasta, '--threads', str(args.cpus), '--out', mibig_blast, '--db', mibig_db, '--max-hsps', '1', '--evalue', '0.001', '--max-target-seqs', '1', '--outfmt', '6']


### PR DESCRIPTION
Gene names from predict_results proteins.fa are stripped of the -T1 suffix, but not those in the set of SM cluster proteins, causing this check to fail. So writing of smcluster.proteins.fasta fails, diamond search fails, and smcluster.MIBiG.blast.txt isn't created.